### PR TITLE
Improved client caching performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM ubuntu
 MAINTAINER Scott Ferguson <scott.ferguson@vokalinteractive.com>
 
 RUN apt-get update -qq
-RUN apt-get install -qqy ca-certificates
+RUN apt-get install -y ca-certificates
 
 ADD ./vip ./vip
+
+EXPOSE 8080
  
 CMD ./vip

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/vokalinteractive/vip/peer"
 	"github.com/vokalinteractive/vip/pg"
 	"github.com/vokalinteractive/vip/store"
+	"go-loggly"
 	"launchpad.net/goamz/aws"
 	"launchpad.net/goamz/ec2"
 	"launchpad.net/goamz/s3"
@@ -61,6 +62,11 @@ func handlePing(w http.ResponseWriter, r *http.Request) {
 
 func init() {
 	flag.Parse()
+
+	loggly_key := os.Getenv("LOGGLY_KEY")
+	if loggly_key != "" {
+		log.SetOutput(loggly.New(loggly_key, "vip"))
+	}
 
 	r := mux.NewRouter()
 	r.HandleFunc("/{bucket_id}/{image_id}", handleImageRequest)


### PR DESCRIPTION
Found a bug where the `Last-Modified` header was always being set to a few seconds after the `If-Modified-Since` request header. In the spirit of groupcache never reusing a key, this CL forces the `Last-Modified` header for every cached response to be 2009-11-10 (birthdate of Go that I shamelessly stole from the docs because :effort:). This means that clients honoring this type of cache header will get a `304 Not Modified` response for subsequent requests on the same URI.

Also, Loggly support with a dinky little library I wrote and some Dockerfile fixes.

@projectweekend @foresmac @Nimzor @clowe3 
