### PR TITLE
Make AWS region variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ func getRegion() aws.Region {
 	case "us-east-1":
 		return aws.USEast
 	default:
+		log.Println("No AWS_REGION parameter provided, defaulting to us-east-1")
 		return aws.USEast
 	}
 }


### PR DESCRIPTION
Title says it all. S3 wants you to establish a connection with a specific region so trying to run Vip anywhere other than us-east-1 would cause an error during upload.
