### PR TITLE
Set content-type header at the proper point

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -103,8 +103,9 @@ func handleUpload(w http.ResponseWriter, r *http.Request) {
 
 	uri.Path = fmt.Sprintf("%s/%s", bucket, key)
 
-	w.WriteHeader(http.StatusCreated)
 	w.Header().Set("Content-Type", "application/json")
+
+	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(UploadResponse{
 		Url: uri.String(),
 	})


### PR DESCRIPTION
Annoying bug in Go's `net/http/httptest` library. The documentation for `http.ResponseWriter` says for a call to `Header()`:

```
Header returns the header map that will be sent by WriteHeader.
Changing the header after a call to WriteHeader (or Write) has
no effect
```

I wasn't following this correctly and was setting the content-type header after calling `WriteHeader()` but the `http.ResponseRecorder` used in my tests to introspect the response claimed that the headers were written as expected. So the original bug wasn't actually fixed, but my tests said that it was.

Reporting the bug upstream, will probably submit a fix.
