### PR TITLE
Fix gif support

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,3 +24,4 @@ publish:
         email: docker@vokalinteractive.com
         image_name: docker.vokalinteractive.com/vip
         tags: [latest]
+        push_latest: true

--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -63,13 +63,6 @@ func ImageData(storage store.ImageStore, gc groupcache.Context) ([]byte, error) 
 		return readImage(reader)
 	}
 
-	// Gifs don't get resized
-	/* TODO: Detect mimetype earlier
-	if c.Mime == "image/gif" {
-		return data, err
-	}
-	*/
-
 	var buf io.Reader
 	if c.Width != 0 {
 		buf, err = Resize(reader, c)

--- a/fetch/manip.go
+++ b/fetch/manip.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/disintegration/imaging"
 	"image"
+	"image/gif"
 	"image/jpeg"
 	"image/png"
 	"io"
@@ -18,6 +19,12 @@ func Resize(src io.Reader, c *CacheContext) (io.Reader, error) {
 	}
 
 	buf := new(bytes.Buffer)
+
+	// Gifs don't get modified
+	if format == "gif" {
+		err = gif.Encode(buf, image, nil)
+		return buf, err
+	}
 
 	factor := float64(c.Width) / float64(image.Bounds().Size().X)
 	height := int(float64(image.Bounds().Size().Y) * factor)
@@ -42,6 +49,12 @@ func CenterCrop(src io.Reader, c *CacheContext) (io.Reader, error) {
 	}
 
 	buf := new(bytes.Buffer)
+
+	// Gifs don't get modified
+	if format == "gif" {
+		err = gif.Encode(buf, image, nil)
+		return buf, err
+	}
 
 	height := image.Bounds().Size().Y
 	width := image.Bounds().Size().X


### PR DESCRIPTION
Gifs shouldn't be modified by Vip but we want to retain the caching benefits. When a resize or crop option is passed to Vip and the image is a gif it should just return the image gracefully.

This bug currently prevents gifs from working in the VokalTalk client and that is a bad thing.
