### PR TITLE
Add error msg when file size exceeds limit

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -93,7 +93,7 @@ func handleUpload(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	bucket := vars["bucket_id"]
 
-	// Set a hard 5mb limit on files
+	// Set a hard limit in MB on files
 	var limit int64 = 5
 	if r.ContentLength > limit<<20 {
 		w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
I looked over the code, and I couldn't find any other time that an obvious error was written without a useful error message. 

Here are the spots where error codes are returned without an error message:
line 36: `401` when X-Vip-Token isn't supplied
line 59, 85: `405`
line 67: `304`

None of those need an error message AFAICT.

Fixes #37 
Fixes vokalinteractive/gozer#38
