### PR TITLE
Simplify square cropping

### DIFF
--- a/fetch/fetch.go
+++ b/fetch/fetch.go
@@ -98,13 +98,6 @@ func ImageData(storage store.ImageStore, gc groupcache.Context) ([]byte, error) 
 		}
 	}
 
-	if c.Crop {
-		buf, err = CenterCrop(buf, c)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	result, err := readImage(buf)
 	if err != nil {
 		return nil, err

--- a/fetch/manip.go
+++ b/fetch/manip.go
@@ -2,10 +2,7 @@ package fetch
 
 import (
 	"bytes"
-	"fmt"
 	"image"
-	"image/jpeg"
-	"image/png"
 	"io"
 	"io/ioutil"
 
@@ -83,40 +80,14 @@ func Resize(src io.Reader, c *CacheContext) (io.Reader, error) {
 		Quality:      80,
 	}
 
+	if c.Crop {
+		options.Height = c.Width
+	}
+
 	res, err := vips.Resize(raw, options)
 	if err != nil {
 		return nil, err
 	}
 
 	return bytes.NewBuffer(res), err
-}
-
-func CenterCrop(src io.Reader, c *CacheContext) (io.Reader, error) {
-	image, format, err := image.Decode(src)
-	if err != nil {
-		fmt.Println(err.Error())
-		return nil, err
-	}
-
-	height := image.Bounds().Size().Y
-	width := image.Bounds().Size().X
-
-	if width < height {
-		image = imaging.CropCenter(image, width, width)
-	} else if width > height {
-		image = imaging.CropCenter(image, height, height)
-	} else {
-		image = imaging.CropCenter(image, width, height)
-	}
-
-	buf := new(bytes.Buffer)
-
-	switch format {
-	case "jpeg":
-		err = jpeg.Encode(buf, image, nil)
-	case "png":
-		err = png.Encode(buf, image)
-	}
-
-	return buf, err
 }

--- a/resize_test.go
+++ b/resize_test.go
@@ -50,7 +50,7 @@ func (s *ResizeSuite) SetUpTest(c *C) {
 }
 
 func (s *ResizeSuite) BenchmarkThumbnailResize(c *C) {
-	file, err := ioutil.ReadFile("test/AWESOME.jpg")
+	file, err := ioutil.ReadFile("test/awesome.jpeg")
 	c.Assert(err, IsNil)
 
 	ctx := &fetch.CacheContext{
@@ -61,12 +61,12 @@ func (s *ResizeSuite) BenchmarkThumbnailResize(c *C) {
 		// Need a new io.Reader on every iteration
 		buf := bytes.NewReader(file)
 		_, err := fetch.Resize(buf, ctx)
-		c.Assert(err, IsNil)
+		c.Check(err, IsNil)
 	}
 }
 
 func (s *ResizeSuite) BenchmarkLargeResize(c *C) {
-	file, err := ioutil.ReadFile("test/AWESOME.jpg")
+	file, err := ioutil.ReadFile("test/awesome.jpeg")
 	c.Assert(err, IsNil)
 
 	ctx := &fetch.CacheContext{
@@ -77,7 +77,24 @@ func (s *ResizeSuite) BenchmarkLargeResize(c *C) {
 		// Need a new io.Reader on every iteration
 		buf := bytes.NewReader(file)
 		_, err := fetch.Resize(buf, ctx)
-		c.Assert(err, IsNil)
+		c.Check(err, IsNil)
+	}
+}
+
+func (s *ResizeSuite) BenchmarkSquareThumbnail(c *C) {
+	file, err := ioutil.ReadFile("test/awesome.jpeg")
+	c.Assert(err, IsNil)
+
+	ctx := &fetch.CacheContext{
+		Width: 180,
+		Crop:  true,
+	}
+
+	for i := 0; i < c.N; i++ {
+		// Need a new io.Reader on every iteration
+		buf := bytes.NewReader(file)
+		_, err := fetch.Resize(buf, ctx)
+		c.Check(err, IsNil)
 	}
 }
 
@@ -105,6 +122,27 @@ func (s *ResizeSuite) TestResizeImage(c *C) {
 		c.Check(err, IsNil)
 		c.Check(image.Bounds().Size().X, Equals, width)
 		c.Check(image.Bounds().Size().Y, Equals, height)
+	}
+}
+
+func (s *ResizeSuite) TestResizeImageSquare(c *C) {
+	file, err := ioutil.ReadFile("test/awesome.jpeg")
+	c.Assert(err, IsNil)
+
+	for width, _ := range sizes {
+		ctx := &fetch.CacheContext{
+			Width: width,
+			Crop:  true,
+		}
+
+		buf := bytes.NewReader(file)
+		resized, err := fetch.Resize(buf, ctx)
+		c.Check(err, IsNil)
+
+		image, _, err := image.Decode(resized)
+		c.Check(err, IsNil)
+		c.Check(image.Bounds().Size().X, Equals, width)
+		c.Check(image.Bounds().Size().Y, Equals, width)
 	}
 }
 


### PR DESCRIPTION
No need to perform an extra step when generating square thumbnails. If
both width and height are specified in `vips.Options`, and it’s the
same value, it just does the right thing.

See code here:
https://github.com/DAddYE/vips/blob/master/vips.go#L124-L148

Added square thumb resize test and benchmark. I tested the difference
between the new and old version; this is only about a 5% savings in
speed, which isn’t much, but it does simplify the code quite a bit.
